### PR TITLE
Update and patch README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Run `source ./scripts/activate.sh`
 
 ## Build
 
-`cd src && idf.py build`
+for esp32:\
+`cd src; rm sdkconfig; idf.py build`
+
+or for m5-Stack:\
+`cd src; rm sdkconfig; idf.py -D 'SDKCONFIG_DEFAULTS=sdkconfig_m5stack.defaults' build`
 
 ## References
 


### PR DESCRIPTION
- added Tutorial for m5-Stack
- now the console removes old sdkconfig file which could cause problems in future versions if you switch between esp32 and m5-stack

# Pull Request Checklist

## Author

- [x] Built code and tested locally
- [x] Removed any TODOs, etc.
- [x] Metioned the issue this PR closes
- [x] Good description of what the PR does written

## Reviewer

- [ ] Built and tested code locally
- [ ] Fully understood the PR
- [ ] All open conversations resolved
